### PR TITLE
Disable legacy workflows and publish image to GHCR

### DIFF
--- a/.github/workflows/build-and-push-ghcr.yml
+++ b/.github/workflows/build-and-push-ghcr.yml
@@ -1,0 +1,38 @@
+name: build-and-push-ghcr
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ github.sha }}

--- a/.github/workflows/main.yml.disabled
+++ b/.github/workflows/main.yml.disabled
@@ -1,0 +1,67 @@
+name: build
+
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  dockerhub-build-push:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y.%m.%d')"
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            VERSION=${{ steps.date.outputs.date }}
+          tags: |
+            ${{ secrets.DOCKERHUB_REPOSITORY }}:latest
+            ${{ secrets.DOCKERHUB_REPOSITORY }}:${{ steps.date.outputs.date }}
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ steps.date.outputs.date }}
+
+  dockerhub-sync-readme:
+    needs: dockerhub-build-push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync README
+        uses: docker://lsiodev/readme-sync:latest
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+          GIT_REPOSITORY: ${{ github.repository }}
+          DOCKER_REPOSITORY: ${{ secrets.DOCKERHUB_REPOSITORY }}
+          GIT_BRANCH: master
+        with:
+          entrypoint: node
+          args: /opt/docker-readme-sync/sync

--- a/.github/workflows/update-yt-dlp.yml.disabled
+++ b/.github/workflows/update-yt-dlp.yml.disabled
@@ -1,0 +1,41 @@
+name: update-yt-dlp
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  update-yt-dlp :
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.AUTOUPDATE_PAT }}
+      -
+        name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.13'
+      -
+        name: Install uv
+        uses: astral-sh/setup-uv@v6
+      -
+        name: Update yt-dlp
+        run: |
+          uv sync --locked
+          # Check if yt-dlp has updates available
+          LATEST_VERSION=$(uv pip list --outdated --format json | jq -r '.[] | select(.name == "yt-dlp") | .latest_version')
+          CURRENT_VERSION=$(uv pip list --format json | jq -r '.[] | select(.name == "yt-dlp") | .version')
+          if [ -n "$LATEST_VERSION" ] && [ "$LATEST_VERSION" != "$CURRENT_VERSION" ]; then
+            echo "Updating yt-dlp from $CURRENT_VERSION to $LATEST_VERSION"
+            uv lock --upgrade-package "yt-dlp[default,curl-cffi]"
+            git config --global user.email "updater@metube"
+            git config --global user.name "AutoUpdater"
+            git add uv.lock
+            git commit -m "upgrade yt-dlp from $CURRENT_VERSION to $LATEST_VERSION"
+            git push
+          else
+            echo "yt-dlp is already up to date ($CURRENT_VERSION)"
+          fi


### PR DESCRIPTION
## Summary
- rename the existing build and updater workflows so they no longer trigger
- add a GitHub Actions workflow that builds and pushes the Docker image to GHCR on every push to master

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68dc34f9f81883239b7700b2db32d3da